### PR TITLE
FIX: Fix failing build on Python 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6,<3.12
     - pip
   run:
     - python >=3.6


### PR DESCRIPTION
Do not use latest version of Python, 3.12
